### PR TITLE
Upgrade to 10.7 packages. Add new OCR engines resource files

### DIFF
--- a/Atalasoft.Demo.Ocr/Atalasoft.Demo.Ocr.csproj
+++ b/Atalasoft.Demo.Ocr/Atalasoft.Demo.Ocr.csproj
@@ -75,48 +75,48 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Atalasoft.dotImage">
-      <HintPath>..\packages\Atalasoft.dotImage.x86.10.6.1.95402\lib\net40\x86\Atalasoft.dotImage.dll</HintPath>
+    <Reference Include="Atalasoft.dotImage, Version=10.7.0.2489, Culture=neutral, PublicKeyToken=2b02b46f7326f73b, processorArchitecture=x86">
+      <HintPath>..\packages\Atalasoft.dotImage.x86.10.7.0.02489\lib\net40\Atalasoft.dotImage.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Atalasoft.dotImage.Lib">
-      <HintPath>..\packages\Atalasoft.dotImage.Lib.x86.10.6.1.95402\lib\net40\x86\Atalasoft.dotImage.Lib.dll</HintPath>
+    <Reference Include="Atalasoft.dotImage.Lib, Version=10.7.0.2489, Culture=neutral, PublicKeyToken=2b02b46f7326f73b, processorArchitecture=x86">
+      <HintPath>..\packages\Atalasoft.dotImage.Lib.x86.10.7.0.02489\lib\net40\Atalasoft.dotImage.Lib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Atalasoft.dotImage.Ocr">
-      <HintPath>..\packages\Atalasoft.dotImage.Ocr.x86.10.6.1.95402\lib\net40\x86\Atalasoft.dotImage.Ocr.dll</HintPath>
+    <Reference Include="Atalasoft.dotImage.Ocr, Version=10.7.0.2489, Culture=neutral, PublicKeyToken=2b02b46f7326f73b, processorArchitecture=x86">
+      <HintPath>..\packages\Atalasoft.dotImage.Ocr.x86.10.7.0.02489\lib\net40\Atalasoft.dotImage.Ocr.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Atalasoft.dotImage.Ocr.GlyphReader">
-      <HintPath>..\packages\Atalasoft.dotImage.Ocr.GlyphReader.x86.10.6.1.95402\lib\net40\x86\Atalasoft.dotImage.Ocr.GlyphReader.dll</HintPath>
+    <Reference Include="Atalasoft.dotImage.Ocr.GlyphReader, Version=10.7.0.2489, Culture=neutral, PublicKeyToken=2b02b46f7326f73b, processorArchitecture=x86">
+      <HintPath>..\packages\Atalasoft.dotImage.Ocr.GlyphReader.x86.10.7.0.02489\lib\net40\Atalasoft.dotImage.Ocr.GlyphReader.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Atalasoft.dotImage.Ocr.Tesseract">
-      <HintPath>..\packages\Atalasoft.dotImage.Ocr.Tesseract.x86.10.6.1.95402\lib\net40\x86\Atalasoft.dotImage.Ocr.Tesseract.dll</HintPath>
+    <Reference Include="Atalasoft.dotImage.Ocr.Tesseract, Version=10.7.0.2489, Culture=neutral, PublicKeyToken=2b02b46f7326f73b, processorArchitecture=x86">
+      <HintPath>..\packages\Atalasoft.dotImage.Ocr.Tesseract.x86.10.7.0.02489\lib\net40\Atalasoft.dotImage.Ocr.Tesseract.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Atalasoft.dotImage.Ocr.Tesseract3">
-      <HintPath>..\packages\Atalasoft.dotImage.Ocr.Tesseract3.x86.10.6.1.95402\lib\net40\x86\Atalasoft.dotImage.Ocr.Tesseract3.dll</HintPath>
+    <Reference Include="Atalasoft.dotImage.Ocr.Tesseract3, Version=10.7.0.2489, Culture=neutral, PublicKeyToken=2b02b46f7326f73b, processorArchitecture=x86">
+      <HintPath>..\packages\Atalasoft.dotImage.Ocr.Tesseract3.x86.10.7.0.02489\lib\net40\Atalasoft.dotImage.Ocr.Tesseract3.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Atalasoft.dotImage.Pdf">
-      <HintPath>..\packages\Atalasoft.dotImage.Pdf.x86.10.6.1.95402\lib\net40\x86\Atalasoft.dotImage.Pdf.dll</HintPath>
+    <Reference Include="Atalasoft.dotImage.Pdf, Version=10.7.0.2489, Culture=neutral, PublicKeyToken=2b02b46f7326f73b, processorArchitecture=x86">
+      <HintPath>..\packages\Atalasoft.dotImage.Pdf.x86.10.7.0.02489\lib\net40\Atalasoft.dotImage.Pdf.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Atalasoft.dotImage.PdfDoc.Bridge">
-      <HintPath>..\packages\Atalasoft.dotImage.PdfDoc.Bridge.x86.10.6.1.95402\lib\net40\x86\Atalasoft.dotImage.PdfDoc.Bridge.dll</HintPath>
+    <Reference Include="Atalasoft.dotImage.PdfDoc.Bridge, Version=10.7.0.2489, Culture=neutral, PublicKeyToken=2b02b46f7326f73b, processorArchitecture=x86">
+      <HintPath>..\packages\Atalasoft.dotImage.PdfDoc.Bridge.x86.10.7.0.02489\lib\net40\Atalasoft.dotImage.PdfDoc.Bridge.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Atalasoft.dotImage.WinControls">
-      <HintPath>..\packages\Atalasoft.dotImage.WinControls.x86.10.6.1.95402\lib\net40\x86\Atalasoft.dotImage.WinControls.dll</HintPath>
+    <Reference Include="Atalasoft.dotImage.WinControls, Version=10.7.0.2489, Culture=neutral, PublicKeyToken=2b02b46f7326f73b, processorArchitecture=x86">
+      <HintPath>..\packages\Atalasoft.dotImage.WinControls.x86.10.7.0.02489\lib\net40\Atalasoft.dotImage.WinControls.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Atalasoft.PdfDoc">
-      <HintPath>..\packages\Atalasoft.PdfDoc.x86.10.6.1.95402\lib\net40\x86\Atalasoft.PdfDoc.dll</HintPath>
+    <Reference Include="Atalasoft.PdfDoc, Version=10.7.0.2489, Culture=neutral, PublicKeyToken=2b02b46f7326f73b, processorArchitecture=x86">
+      <HintPath>..\packages\Atalasoft.PdfDoc.x86.10.7.0.02489\lib\net40\Atalasoft.PdfDoc.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Atalasoft.Shared">
-      <HintPath>..\packages\Atalasoft.Shared.10.6.1.95402\lib\net40\x86\Atalasoft.Shared.dll</HintPath>
+    <Reference Include="Atalasoft.Shared, Version=10.7.0.2489, Culture=neutral, PublicKeyToken=2b02b46f7326f73b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Atalasoft.Shared.10.7.0.02489\lib\net40\Atalasoft.Shared.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System">
@@ -198,29 +198,35 @@
   <Target Name="AfterBuild">
     <Copy SourceFiles="$(AppConfigFile)" DestinationFiles="$(TargetPath).config" SkipUnchangedFiles="false" />
   </Target>
+  <Import Project="..\packages\Atalasoft.dotImage.Lib.x86.10.7.0.02489\build\Atalasoft.dotImage.Lib.x86.targets" Condition="Exists('..\packages\Atalasoft.dotImage.Lib.x86.10.7.0.02489\build\Atalasoft.dotImage.Lib.x86.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.Lib.x86.10.6.1.95402\build\Atalasoft.dotImage.Lib.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.Lib.x86.10.6.1.95402\build\Atalasoft.dotImage.Lib.x86.targets'))" />
-    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.x86.10.6.1.95402\build\Atalasoft.dotImage.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.x86.10.6.1.95402\build\Atalasoft.dotImage.x86.targets'))" />
-    <Error Condition="!Exists('..\packages\Atalasoft.PdfDoc.x86.10.6.1.95402\build\Atalasoft.PdfDoc.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.PdfDoc.x86.10.6.1.95402\build\Atalasoft.PdfDoc.x86.targets'))" />
-    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.Ocr.x86.10.6.1.95402\build\Atalasoft.dotImage.Ocr.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.Ocr.x86.10.6.1.95402\build\Atalasoft.dotImage.Ocr.x86.targets'))" />
-    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.Ocr.GlyphReader.x86.10.6.1.95402\build\Atalasoft.dotImage.Ocr.GlyphReader.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.Ocr.GlyphReader.x86.10.6.1.95402\build\Atalasoft.dotImage.Ocr.GlyphReader.x86.targets'))" />
-    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.Ocr.Tesseract.x86.10.6.1.95402\build\Atalasoft.dotImage.Ocr.Tesseract.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.Ocr.Tesseract.x86.10.6.1.95402\build\Atalasoft.dotImage.Ocr.Tesseract.x86.targets'))" />
-    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.Ocr.Tesseract3.x86.10.6.1.95402\build\Atalasoft.dotImage.Ocr.Tesseract3.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.Ocr.Tesseract3.x86.10.6.1.95402\build\Atalasoft.dotImage.Ocr.Tesseract3.x86.targets'))" />
-    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.Pdf.x86.10.6.1.95402\build\Atalasoft.dotImage.Pdf.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.Pdf.x86.10.6.1.95402\build\Atalasoft.dotImage.Pdf.x86.targets'))" />
-    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.PdfDoc.Bridge.x86.10.6.1.95402\build\Atalasoft.dotImage.PdfDoc.Bridge.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.PdfDoc.Bridge.x86.10.6.1.95402\build\Atalasoft.dotImage.PdfDoc.Bridge.x86.targets'))" />
-    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.WinControls.x86.10.6.1.95402\build\Atalasoft.dotImage.WinControls.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.WinControls.x86.10.6.1.95402\build\Atalasoft.dotImage.WinControls.x86.targets'))" />
+    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.Lib.x86.10.7.0.02489\build\Atalasoft.dotImage.Lib.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.Lib.x86.10.7.0.02489\build\Atalasoft.dotImage.Lib.x86.targets'))" />
+    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.x86.10.7.0.02489\build\Atalasoft.dotImage.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.x86.10.7.0.02489\build\Atalasoft.dotImage.x86.targets'))" />
+    <Error Condition="!Exists('..\packages\Atalasoft.PdfDoc.x86.10.7.0.02489\build\Atalasoft.PdfDoc.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.PdfDoc.x86.10.7.0.02489\build\Atalasoft.PdfDoc.x86.targets'))" />
+    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.Ocr.x86.10.7.0.02489\build\Atalasoft.dotImage.Ocr.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.Ocr.x86.10.7.0.02489\build\Atalasoft.dotImage.Ocr.x86.targets'))" />
+    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.Ocr.GlyphReader.x86.10.7.0.02489\build\Atalasoft.dotImage.Ocr.GlyphReader.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.Ocr.GlyphReader.x86.10.7.0.02489\build\Atalasoft.dotImage.Ocr.GlyphReader.x86.targets'))" />
+    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.Ocr.Tesseract.x86.10.7.0.02489\build\Atalasoft.dotImage.Ocr.Tesseract.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.Ocr.Tesseract.x86.10.7.0.02489\build\Atalasoft.dotImage.Ocr.Tesseract.x86.targets'))" />
+    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.Ocr.Tesseract3.x86.10.7.0.02489\build\Atalasoft.dotImage.Ocr.Tesseract3.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.Ocr.Tesseract3.x86.10.7.0.02489\build\Atalasoft.dotImage.Ocr.Tesseract3.x86.targets'))" />
+    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.Pdf.x86.10.7.0.02489\build\Atalasoft.dotImage.Pdf.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.Pdf.x86.10.7.0.02489\build\Atalasoft.dotImage.Pdf.x86.targets'))" />
+    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.PdfDoc.Bridge.x86.10.7.0.02489\build\Atalasoft.dotImage.PdfDoc.Bridge.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.PdfDoc.Bridge.x86.10.7.0.02489\build\Atalasoft.dotImage.PdfDoc.Bridge.x86.targets'))" />
+    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.WinControls.x86.10.7.0.02489\build\Atalasoft.dotImage.WinControls.x86.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.WinControls.x86.10.7.0.02489\build\Atalasoft.dotImage.WinControls.x86.targets'))" />
+    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.Ocr.Tesseract.Resources.10.7.0.02483\build\Atalasoft.dotImage.Ocr.Tesseract.Resources.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.Ocr.Tesseract.Resources.10.7.0.02483\build\Atalasoft.dotImage.Ocr.Tesseract.Resources.targets'))" />
+    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.Ocr.Tesseract3.Resources.10.7.0.02483\build\Atalasoft.dotImage.Ocr.Tesseract3.Resources.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.Ocr.Tesseract3.Resources.10.7.0.02483\build\Atalasoft.dotImage.Ocr.Tesseract3.Resources.targets'))" />
+    <Error Condition="!Exists('..\packages\Atalasoft.dotImage.Ocr.GlyphReader.Resources.10.7.0.02483\build\Atalasoft.dotImage.Ocr.GlyphReader.Resources.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Atalasoft.dotImage.Ocr.GlyphReader.Resources.10.7.0.02483\build\Atalasoft.dotImage.Ocr.GlyphReader.Resources.targets'))" />
   </Target>
-  <Import Project="..\packages\Atalasoft.dotImage.Lib.x86.10.6.1.95402\build\Atalasoft.dotImage.Lib.x86.targets" Condition="Exists('..\packages\Atalasoft.dotImage.Lib.x86.10.6.1.95402\build\Atalasoft.dotImage.Lib.x86.targets')" />
-  <Import Project="..\packages\Atalasoft.dotImage.x86.10.6.1.95402\build\Atalasoft.dotImage.x86.targets" Condition="Exists('..\packages\Atalasoft.dotImage.x86.10.6.1.95402\build\Atalasoft.dotImage.x86.targets')" />
-  <Import Project="..\packages\Atalasoft.PdfDoc.x86.10.6.1.95402\build\Atalasoft.PdfDoc.x86.targets" Condition="Exists('..\packages\Atalasoft.PdfDoc.x86.10.6.1.95402\build\Atalasoft.PdfDoc.x86.targets')" />
-  <Import Project="..\packages\Atalasoft.dotImage.Ocr.x86.10.6.1.95402\build\Atalasoft.dotImage.Ocr.x86.targets" Condition="Exists('..\packages\Atalasoft.dotImage.Ocr.x86.10.6.1.95402\build\Atalasoft.dotImage.Ocr.x86.targets')" />
-  <Import Project="..\packages\Atalasoft.dotImage.Ocr.GlyphReader.x86.10.6.1.95402\build\Atalasoft.dotImage.Ocr.GlyphReader.x86.targets" Condition="Exists('..\packages\Atalasoft.dotImage.Ocr.GlyphReader.x86.10.6.1.95402\build\Atalasoft.dotImage.Ocr.GlyphReader.x86.targets')" />
-  <Import Project="..\packages\Atalasoft.dotImage.Ocr.Tesseract.x86.10.6.1.95402\build\Atalasoft.dotImage.Ocr.Tesseract.x86.targets" Condition="Exists('..\packages\Atalasoft.dotImage.Ocr.Tesseract.x86.10.6.1.95402\build\Atalasoft.dotImage.Ocr.Tesseract.x86.targets')" />
-  <Import Project="..\packages\Atalasoft.dotImage.Ocr.Tesseract3.x86.10.6.1.95402\build\Atalasoft.dotImage.Ocr.Tesseract3.x86.targets" Condition="Exists('..\packages\Atalasoft.dotImage.Ocr.Tesseract3.x86.10.6.1.95402\build\Atalasoft.dotImage.Ocr.Tesseract3.x86.targets')" />
-  <Import Project="..\packages\Atalasoft.dotImage.Pdf.x86.10.6.1.95402\build\Atalasoft.dotImage.Pdf.x86.targets" Condition="Exists('..\packages\Atalasoft.dotImage.Pdf.x86.10.6.1.95402\build\Atalasoft.dotImage.Pdf.x86.targets')" />
-  <Import Project="..\packages\Atalasoft.dotImage.PdfDoc.Bridge.x86.10.6.1.95402\build\Atalasoft.dotImage.PdfDoc.Bridge.x86.targets" Condition="Exists('..\packages\Atalasoft.dotImage.PdfDoc.Bridge.x86.10.6.1.95402\build\Atalasoft.dotImage.PdfDoc.Bridge.x86.targets')" />
-  <Import Project="..\packages\Atalasoft.dotImage.WinControls.x86.10.6.1.95402\build\Atalasoft.dotImage.WinControls.x86.targets" Condition="Exists('..\packages\Atalasoft.dotImage.WinControls.x86.10.6.1.95402\build\Atalasoft.dotImage.WinControls.x86.targets')" />
+  <Import Project="..\packages\Atalasoft.dotImage.x86.10.7.0.02489\build\Atalasoft.dotImage.x86.targets" Condition="Exists('..\packages\Atalasoft.dotImage.x86.10.7.0.02489\build\Atalasoft.dotImage.x86.targets')" />
+  <Import Project="..\packages\Atalasoft.PdfDoc.x86.10.7.0.02489\build\Atalasoft.PdfDoc.x86.targets" Condition="Exists('..\packages\Atalasoft.PdfDoc.x86.10.7.0.02489\build\Atalasoft.PdfDoc.x86.targets')" />
+  <Import Project="..\packages\Atalasoft.dotImage.Ocr.x86.10.7.0.02489\build\Atalasoft.dotImage.Ocr.x86.targets" Condition="Exists('..\packages\Atalasoft.dotImage.Ocr.x86.10.7.0.02489\build\Atalasoft.dotImage.Ocr.x86.targets')" />
+  <Import Project="..\packages\Atalasoft.dotImage.Ocr.GlyphReader.x86.10.7.0.02489\build\Atalasoft.dotImage.Ocr.GlyphReader.x86.targets" Condition="Exists('..\packages\Atalasoft.dotImage.Ocr.GlyphReader.x86.10.7.0.02489\build\Atalasoft.dotImage.Ocr.GlyphReader.x86.targets')" />
+  <Import Project="..\packages\Atalasoft.dotImage.Ocr.Tesseract.x86.10.7.0.02489\build\Atalasoft.dotImage.Ocr.Tesseract.x86.targets" Condition="Exists('..\packages\Atalasoft.dotImage.Ocr.Tesseract.x86.10.7.0.02489\build\Atalasoft.dotImage.Ocr.Tesseract.x86.targets')" />
+  <Import Project="..\packages\Atalasoft.dotImage.Ocr.Tesseract3.x86.10.7.0.02489\build\Atalasoft.dotImage.Ocr.Tesseract3.x86.targets" Condition="Exists('..\packages\Atalasoft.dotImage.Ocr.Tesseract3.x86.10.7.0.02489\build\Atalasoft.dotImage.Ocr.Tesseract3.x86.targets')" />
+  <Import Project="..\packages\Atalasoft.dotImage.Pdf.x86.10.7.0.02489\build\Atalasoft.dotImage.Pdf.x86.targets" Condition="Exists('..\packages\Atalasoft.dotImage.Pdf.x86.10.7.0.02489\build\Atalasoft.dotImage.Pdf.x86.targets')" />
+  <Import Project="..\packages\Atalasoft.dotImage.PdfDoc.Bridge.x86.10.7.0.02489\build\Atalasoft.dotImage.PdfDoc.Bridge.x86.targets" Condition="Exists('..\packages\Atalasoft.dotImage.PdfDoc.Bridge.x86.10.7.0.02489\build\Atalasoft.dotImage.PdfDoc.Bridge.x86.targets')" />
+  <Import Project="..\packages\Atalasoft.dotImage.WinControls.x86.10.7.0.02489\build\Atalasoft.dotImage.WinControls.x86.targets" Condition="Exists('..\packages\Atalasoft.dotImage.WinControls.x86.10.7.0.02489\build\Atalasoft.dotImage.WinControls.x86.targets')" />
+  <Import Project="..\packages\Atalasoft.dotImage.Ocr.Tesseract.Resources.10.7.0.02483\build\Atalasoft.dotImage.Ocr.Tesseract.Resources.targets" Condition="Exists('..\packages\Atalasoft.dotImage.Ocr.Tesseract.Resources.10.7.0.02483\build\Atalasoft.dotImage.Ocr.Tesseract.Resources.targets')" />
+  <Import Project="..\packages\Atalasoft.dotImage.Ocr.Tesseract3.Resources.10.7.0.02483\build\Atalasoft.dotImage.Ocr.Tesseract3.Resources.targets" Condition="Exists('..\packages\Atalasoft.dotImage.Ocr.Tesseract3.Resources.10.7.0.02483\build\Atalasoft.dotImage.Ocr.Tesseract3.Resources.targets')" />
+  <Import Project="..\packages\Atalasoft.dotImage.Ocr.GlyphReader.Resources.10.7.0.02483\build\Atalasoft.dotImage.Ocr.GlyphReader.Resources.targets" Condition="Exists('..\packages\Atalasoft.dotImage.Ocr.GlyphReader.Resources.10.7.0.02483\build\Atalasoft.dotImage.Ocr.GlyphReader.Resources.targets')" />
 </Project>

--- a/Atalasoft.Demo.Ocr/packages.config
+++ b/Atalasoft.Demo.Ocr/packages.config
@@ -1,14 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Atalasoft.dotImage.Lib.x86" version="10.6.1.95402" targetFramework="net40" />
-  <package id="Atalasoft.dotImage.Ocr.GlyphReader.x86" version="10.6.1.95402" targetFramework="net40" />
-  <package id="Atalasoft.dotImage.Ocr.Tesseract.x86" version="10.6.1.95402" targetFramework="net40" />
-  <package id="Atalasoft.dotImage.Ocr.Tesseract3.x86" version="10.6.1.95402" targetFramework="net40" />
-  <package id="Atalasoft.dotImage.Ocr.x86" version="10.6.1.95402" targetFramework="net40" />
-  <package id="Atalasoft.dotImage.Pdf.x86" version="10.6.1.95402" targetFramework="net40" />
-  <package id="Atalasoft.dotImage.PdfDoc.Bridge.x86" version="10.6.1.95402" targetFramework="net40" />
-  <package id="Atalasoft.dotImage.WinControls.x86" version="10.6.1.95402" targetFramework="net40" />
-  <package id="Atalasoft.dotImage.x86" version="10.6.1.95402" targetFramework="net40" />
-  <package id="Atalasoft.PdfDoc.x86" version="10.6.1.95402" targetFramework="net40" />
-  <package id="Atalasoft.Shared" version="10.6.1.95402" targetFramework="net40" />
+  <package id="Atalasoft.dotImage.Lib.x86" version="10.7.0.02489" targetFramework="net40" />
+  <package id="Atalasoft.dotImage.Ocr.GlyphReader.Resources" version="10.7.0.02483" targetFramework="net40" />
+  <package id="Atalasoft.dotImage.Ocr.GlyphReader.x86" version="10.7.0.02489" targetFramework="net40" />
+  <package id="Atalasoft.dotImage.Ocr.Tesseract.Resources" version="10.7.0.02483" targetFramework="net40" />
+  <package id="Atalasoft.dotImage.Ocr.Tesseract.x86" version="10.7.0.02489" targetFramework="net40" />
+  <package id="Atalasoft.dotImage.Ocr.Tesseract3.Resources" version="10.7.0.02483" targetFramework="net40" />
+  <package id="Atalasoft.dotImage.Ocr.Tesseract3.x86" version="10.7.0.02489" targetFramework="net40" />
+  <package id="Atalasoft.dotImage.Ocr.x86" version="10.7.0.02489" targetFramework="net40" />
+  <package id="Atalasoft.dotImage.Pdf.x86" version="10.7.0.02489" targetFramework="net40" />
+  <package id="Atalasoft.dotImage.PdfDoc.Bridge.x86" version="10.7.0.02489" targetFramework="net40" />
+  <package id="Atalasoft.dotImage.WinControls.x86" version="10.7.0.02489" targetFramework="net40" />
+  <package id="Atalasoft.dotImage.x86" version="10.7.0.02489" targetFramework="net40" />
+  <package id="Atalasoft.PdfDoc.x86" version="10.7.0.02489" targetFramework="net40" />
+  <package id="Atalasoft.Shared" version="10.7.0.02489" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Now it is possible to download complete OCR engine files using NuGet packages! It means that OCR Demo is not complete and can be used to extract text from images out of the box.
